### PR TITLE
Add Try<SuccessType>

### DIFF
--- a/ScreamEssentials.xcodeproj/project.pbxproj
+++ b/ScreamEssentials.xcodeproj/project.pbxproj
@@ -53,6 +53,13 @@
 		9588127C2096C71A0080D3D4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9588127B2096C71A0080D3D4 /* Assets.xcassets */; };
 		958812802096C71A0080D3D4 /* ScreamEssentialsExample-watch.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 958812662096C7190080D3D4 /* ScreamEssentialsExample-watch.app */; };
 		958812B72096ED170080D3D4 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 958812B62096ED170080D3D4 /* main.swift */; };
+		95B27C47212669FD0008A519 /* Try.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B27C46212669FD0008A519 /* Try.swift */; };
+		95B27C48212669FD0008A519 /* Try.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B27C46212669FD0008A519 /* Try.swift */; };
+		95B27C49212669FD0008A519 /* Try.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B27C46212669FD0008A519 /* Try.swift */; };
+		95B27C4A212669FD0008A519 /* Try.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B27C46212669FD0008A519 /* Try.swift */; };
+		95B27C4C21266BA80008A519 /* TryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B27C4B21266BA80008A519 /* TryTests.swift */; };
+		95B27C4D21266BA80008A519 /* TryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B27C4B21266BA80008A519 /* TryTests.swift */; };
+		95B27C4E21266BA80008A519 /* TryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B27C4B21266BA80008A519 /* TryTests.swift */; };
 		95B622F52111E3AF00CF8E7F /* Cancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B622F42111E3AF00CF8E7F /* Cancellable.swift */; };
 		95B622F62111E3AF00CF8E7F /* Cancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B622F42111E3AF00CF8E7F /* Cancellable.swift */; };
 		95B622F72111E3AF00CF8E7F /* Cancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B622F42111E3AF00CF8E7F /* Cancellable.swift */; };
@@ -254,6 +261,8 @@
 		958812FC2097F5470080D3D4 /* TestTarget-ios.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "TestTarget-ios.xcconfig"; sourceTree = "<group>"; };
 		958813012097F8B70080D3D4 /* Tests-tv.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Tests-tv.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		958813112097FB130080D3D4 /* TestTarget-tv.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "TestTarget-tv.xcconfig"; sourceTree = "<group>"; };
+		95B27C46212669FD0008A519 /* Try.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Try.swift; sourceTree = "<group>"; };
+		95B27C4B21266BA80008A519 /* TryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TryTests.swift; sourceTree = "<group>"; };
 		95B622F42111E3AF00CF8E7F /* Cancellable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cancellable.swift; sourceTree = "<group>"; };
 		95B622F92111E3EA00CF8E7F /* CancellableAggregator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancellableAggregator.swift; sourceTree = "<group>"; };
 		95B622FE2111E43200CF8E7F /* DispatchQueue+Cancellable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchQueue+Cancellable.swift"; sourceTree = "<group>"; };
@@ -418,6 +427,7 @@
 				95499A2D20EDE81E002ED05D /* DispatchQueue+CancellableTests.swift */,
 				951B161521195F1A00566525 /* Dictionary+PolyfillTests.swift */,
 				951B16192119625100566525 /* ResultTests.swift */,
+				95B27C4B21266BA80008A519 /* TryTests.swift */,
 				958812D8209745FE0080D3D4 /* Info.plist */,
 			);
 			path = Tests;
@@ -467,6 +477,7 @@
 				95B623122111E53900CF8E7F /* Dictionary+Polyfill.swift */,
 				95B622FE2111E43200CF8E7F /* DispatchQueue+Cancellable.swift */,
 				95B623032111E47800CF8E7F /* Result.swift */,
+				95B27C46212669FD0008A519 /* Try.swift */,
 				95D06BA120AAB407005D6947 /* FrameworkInfo.plist */,
 			);
 			path = Source;
@@ -1011,6 +1022,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				95B27C47212669FD0008A519 /* Try.swift in Sources */,
 				95B623132111E53900CF8E7F /* Dictionary+Polyfill.swift in Sources */,
 				95B622FF2111E43200CF8E7F /* DispatchQueue+Cancellable.swift in Sources */,
 				95B623042111E47800CF8E7F /* Result.swift in Sources */,
@@ -1024,6 +1036,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				95B27C48212669FD0008A519 /* Try.swift in Sources */,
 				95B623142111E53900CF8E7F /* Dictionary+Polyfill.swift in Sources */,
 				95B623002111E43200CF8E7F /* DispatchQueue+Cancellable.swift in Sources */,
 				95B623052111E47800CF8E7F /* Result.swift in Sources */,
@@ -1066,6 +1079,7 @@
 				951B161A2119625100566525 /* ResultTests.swift in Sources */,
 				951B161621195F1A00566525 /* Dictionary+PolyfillTests.swift in Sources */,
 				951B16122119548C00566525 /* AutoCancellableAggregatorTests.swift in Sources */,
+				95B27C4E21266BA80008A519 /* TryTests.swift in Sources */,
 				95B6231821127C8500CF8E7F /* AtomicTests.swift in Sources */,
 				951B160E2119523800566525 /* CancellableAggregatorTests.swift in Sources */,
 				95499A2E20EDE81E002ED05D /* DispatchQueue+CancellableTests.swift in Sources */,
@@ -1079,6 +1093,7 @@
 				951B161B2119625100566525 /* ResultTests.swift in Sources */,
 				951B161721195F1A00566525 /* Dictionary+PolyfillTests.swift in Sources */,
 				951B16132119548C00566525 /* AutoCancellableAggregatorTests.swift in Sources */,
+				95B27C4D21266BA80008A519 /* TryTests.swift in Sources */,
 				95B6231921127C8500CF8E7F /* AtomicTests.swift in Sources */,
 				951B160F2119523800566525 /* CancellableAggregatorTests.swift in Sources */,
 				95499A2F20EDE81E002ED05D /* DispatchQueue+CancellableTests.swift in Sources */,
@@ -1092,6 +1107,7 @@
 				951B161C2119625100566525 /* ResultTests.swift in Sources */,
 				951B161821195F1A00566525 /* Dictionary+PolyfillTests.swift in Sources */,
 				951B16142119548C00566525 /* AutoCancellableAggregatorTests.swift in Sources */,
+				95B27C4C21266BA80008A519 /* TryTests.swift in Sources */,
 				95B6231A21127C8500CF8E7F /* AtomicTests.swift in Sources */,
 				951B16102119523800566525 /* CancellableAggregatorTests.swift in Sources */,
 				95499A3020EDE81E002ED05D /* DispatchQueue+CancellableTests.swift in Sources */,
@@ -1111,6 +1127,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				95B27C49212669FD0008A519 /* Try.swift in Sources */,
 				95B623152111E53900CF8E7F /* Dictionary+Polyfill.swift in Sources */,
 				95B623012111E43200CF8E7F /* DispatchQueue+Cancellable.swift in Sources */,
 				95B623062111E47800CF8E7F /* Result.swift in Sources */,
@@ -1124,6 +1141,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				95B27C4A212669FD0008A519 /* Try.swift in Sources */,
 				95B623162111E53900CF8E7F /* Dictionary+Polyfill.swift in Sources */,
 				95B623022111E43200CF8E7F /* DispatchQueue+Cancellable.swift in Sources */,
 				95B623072111E47800CF8E7F /* Result.swift in Sources */,

--- a/Source/Try.swift
+++ b/Source/Try.swift
@@ -1,0 +1,66 @@
+//   Copyright 2018 Alex Deem
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+import Foundation
+
+public struct Try<SuccessType> {
+    private enum _Try {
+        case success(SuccessType)
+        case error(Error)
+    }
+    private let _try: _Try
+
+    public init(success: SuccessType) {
+        _try = .success(success)
+    }
+
+    public init(error: Error) {
+        _try = .error(error)
+    }
+
+    public init(_ closure: () throws -> SuccessType) {
+        do {
+            _try = .success(try closure())
+        } catch let error {
+            _try = .error(error)
+        }
+    }
+
+    public init<ErrorType>(_ result: Result<SuccessType, ErrorType>) {
+        switch result {
+        case let .success(value):
+            _try = .success(value)
+        case let .error(error):
+            _try = .error(error)
+        }
+    }
+
+    public func unwrap() throws -> SuccessType {
+        switch _try {
+        case let .success(value):
+            return value
+        case let .error(error):
+            throw error
+        }
+    }
+
+    public func map<TargetSuccessType>(_ transform: (SuccessType) throws -> TargetSuccessType ) rethrows -> Try<TargetSuccessType> {
+        switch _try {
+        case let .success(value):
+            return Try<TargetSuccessType>(success: try transform(value))
+        case let .error(error):
+            return Try<TargetSuccessType>(error: error)
+        }
+    }
+}

--- a/Tests/TryTests.swift
+++ b/Tests/TryTests.swift
@@ -1,0 +1,118 @@
+//   Copyright 2018 Alex Deem
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+import XCTest
+import ScreamEssentials
+
+enum TryTestError: Error {
+    case a
+    case b
+}
+
+class TryTests: XCTestCase {
+
+    func test_Init_Success() {
+        let result = Try(success: "A")
+        do {
+            let string = try result.unwrap()
+            XCTAssertEqual(string, "A")
+        } catch {
+            XCTFail("unexpected error case")
+        }
+    }
+
+    func test_Init_Error() {
+        let result = Try<String>(error: TryTestError.b)
+        do {
+            let string = try result.unwrap()
+            XCTFail("unexpected success case, \(string)")
+        } catch TryTestError.b {
+        } catch {
+            XCTFail("unexpected error case")
+        }
+    }
+
+    func test_InitWithResult_Success() {
+        let result: Result<String, TryTestError> = .success("A")
+        let t = Try(result)
+        do {
+            let string = try t.unwrap()
+            XCTAssertEqual(string, "A")
+        } catch {
+            XCTFail("unexpected error case")
+        }
+    }
+
+    func test_InitWithResult_Error() {
+        let result: Result<String, TryTestError> = .error(TryTestError.b)
+        let t = Try(result)
+        do {
+            let string = try t.unwrap()
+            XCTFail("unexpected success case, \(string)")
+        } catch TryTestError.b {
+        } catch {
+            XCTFail("unexpected error case")
+        }
+    }
+
+
+    func test_Unwrap_Success() {
+        let result: Try<String> = Try {
+            return "A"
+        }
+        do {
+            let string = try result.unwrap()
+            XCTAssertEqual(string, "A")
+        } catch {
+            XCTFail("unexpected error case")
+        }
+    }
+
+    func test_Unwrap_Error() {
+        let result: Try<String> = Try {
+            throw TryTestError.b
+        }
+        do {
+            let string = try result.unwrap()
+            XCTFail("unexpected success case, \(string)")
+        } catch TryTestError.b {
+        } catch {
+            XCTFail("unexpected error case")
+        }
+    }
+
+    func test_Map_Success() {
+        let result = Try(success: 12)
+        do {
+            let doubled = result.map { 2 * $0 }
+            let value = try doubled.unwrap()
+            XCTAssertEqual(value, 24)
+        } catch {
+            XCTFail("unexpected error case")
+        }
+    }
+
+    func test_Map_Error() {
+        let result = Try<Int>(error: TryTestError.b)
+        do {
+            let doubled = result.map { 2 * $0 }
+            let value = try doubled.unwrap()
+            XCTFail("unexpected success case, \(value)")
+        } catch TryTestError.b {
+        } catch {
+            XCTFail("unexpected error case")
+        }
+    }
+
+}


### PR DESCRIPTION
This is similar to Result<SuccessType, ErrorType> but tailored to purely
being used to wrap and unwrap either a SuccessType or an exception. This
means we don’t specify the ErrorType, and is thus more generic.

Specifically it can be used in protocols without binding an
implementation to a specific ErrorType or requiring it to be specified
with an associated type.